### PR TITLE
Fixed failing META test relating to licence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Rakudo compilation cache
+.precomp
+
+# Vim temporary file
+*.swp

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+		       The Artistic License 2.0
+
+	    Copyright (c) 2000-2006, The Perl Foundation.
+
+     Everyone is permitted to copy and distribute verbatim copies
+      of this license document, but changing it is not allowed.
+
+Preamble
+
+This license establishes the terms under which a given free software
+Package may be copied, modified, distributed, and/or redistributed.
+The intent is that the Copyright Holder maintains some artistic
+control over the development of that Package while still keeping the
+Package available as open source and free software.
+
+You are always permitted to make arrangements wholly outside of this
+license directly with the Copyright Holder of a given Package.  If the
+terms of this license do not permit the full use that you propose to
+make of the Package, you should contact the Copyright Holder and seek
+a different licensing arrangement. 
+
+Definitions
+
+    "Copyright Holder" means the individual(s) or organization(s)
+    named in the copyright notice for the entire Package.
+
+    "Contributor" means any party that has contributed code or other
+    material to the Package, in accordance with the Copyright Holder's
+    procedures.
+
+    "You" and "your" means any person who would like to copy,
+    distribute, or modify the Package.
+
+    "Package" means the collection of files distributed by the
+    Copyright Holder, and derivatives of that collection and/or of
+    those files. A given Package may consist of either the Standard
+    Version, or a Modified Version.
+
+    "Distribute" means providing a copy of the Package or making it
+    accessible to anyone else, or in the case of a company or
+    organization, to others outside of your company or organization.
+
+    "Distributor Fee" means any fee that you charge for Distributing
+    this Package or providing support for this Package to another
+    party.  It does not mean licensing fees.
+
+    "Standard Version" refers to the Package if it has not been
+    modified, or has been modified only in ways explicitly requested
+    by the Copyright Holder.
+
+    "Modified Version" means the Package, if it has been changed, and
+    such changes were not explicitly requested by the Copyright
+    Holder. 
+
+    "Original License" means this Artistic License as Distributed with
+    the Standard Version of the Package, in its current version or as
+    it may be modified by The Perl Foundation in the future.
+
+    "Source" form means the source code, documentation source, and
+    configuration files for the Package.
+
+    "Compiled" form means the compiled bytecode, object code, binary,
+    or any other form resulting from mechanical transformation or
+    translation of the Source form.
+
+
+Permission for Use and Modification Without Distribution
+
+(1)  You are permitted to use the Standard Version and create and use
+Modified Versions for any purpose without restriction, provided that
+you do not Distribute the Modified Version.
+
+
+Permissions for Redistribution of the Standard Version
+
+(2)  You may Distribute verbatim copies of the Source form of the
+Standard Version of this Package in any medium without restriction,
+either gratis or for a Distributor Fee, provided that you duplicate
+all of the original copyright notices and associated disclaimers.  At
+your discretion, such verbatim copies may or may not include a
+Compiled form of the Package.
+
+(3)  You may apply any bug fixes, portability changes, and other
+modifications made available from the Copyright Holder.  The resulting
+Package will still be considered the Standard Version, and as such
+will be subject to the Original License.
+
+
+Distribution of Modified Versions of the Package as Source 
+
+(4)  You may Distribute your Modified Version as Source (either gratis
+or for a Distributor Fee, and with or without a Compiled form of the
+Modified Version) provided that you clearly document how it differs
+from the Standard Version, including, but not limited to, documenting
+any non-standard features, executables, or modules, and provided that
+you do at least ONE of the following:
+
+    (a)  make the Modified Version available to the Copyright Holder
+    of the Standard Version, under the Original License, so that the
+    Copyright Holder may include your modifications in the Standard
+    Version.
+
+    (b)  ensure that installation of your Modified Version does not
+    prevent the user installing or running the Standard Version. In
+    addition, the Modified Version must bear a name that is different
+    from the name of the Standard Version.
+
+    (c)  allow anyone who receives a copy of the Modified Version to
+    make the Source form of the Modified Version available to others
+    under
+		
+	(i)  the Original License or
+
+	(ii)  a license that permits the licensee to freely copy,
+	modify and redistribute the Modified Version using the same
+	licensing terms that apply to the copy that the licensee
+	received, and requires that the Source form of the Modified
+	Version, and of any works derived from it, be made freely
+	available in that license fees are prohibited but Distributor
+	Fees are allowed.
+
+
+Distribution of Compiled Forms of the Standard Version 
+or Modified Versions without the Source
+
+(5)  You may Distribute Compiled forms of the Standard Version without
+the Source, provided that you include complete instructions on how to
+get the Source of the Standard Version.  Such instructions must be
+valid at the time of your distribution.  If these instructions, at any
+time while you are carrying out such distribution, become invalid, you
+must provide new instructions on demand or cease further distribution.
+If you provide valid instructions or cease distribution within thirty
+days after you become aware that the instructions are invalid, then
+you do not forfeit any of your rights under this license.
+
+(6)  You may Distribute a Modified Version in Compiled form without
+the Source, provided that you comply with Section 4 with respect to
+the Source of the Modified Version.
+
+
+Aggregating or Linking the Package 
+
+(7)  You may aggregate the Package (either the Standard Version or
+Modified Version) with other packages and Distribute the resulting
+aggregation provided that you do not charge a licensing fee for the
+Package.  Distributor Fees are permitted, and licensing fees for other
+components in the aggregation are permitted. The terms of this license
+apply to the use and Distribution of the Standard or Modified Versions
+as included in the aggregation.
+
+(8) You are permitted to link Modified and Standard Versions with
+other works, to embed the Package in a larger work of your own, or to
+build stand-alone binary or bytecode versions of applications that
+include the Package, and Distribute the result without restriction,
+provided the result does not expose a direct interface to the Package.
+
+
+Items That are Not Considered Part of a Modified Version 
+
+(9) Works (including, but not limited to, modules and scripts) that
+merely extend or make use of the Package, do not, by themselves, cause
+the Package to be a Modified Version.  In addition, such works are not
+considered parts of the Package itself, and are not subject to the
+terms of this license.
+
+
+General Provisions
+
+(10)  Any use, modification, and distribution of the Standard or
+Modified Versions is governed by this Artistic License. By using,
+modifying or distributing the Package, you accept this license. Do not
+use, modify, or distribute the Package, if you do not accept this
+license.
+
+(11)  If your Modified Version has been derived from a Modified
+Version made by someone other than you, you are nevertheless required
+to ensure that your Modified Version complies with the requirements of
+this license.
+
+(12)  This license does not grant you the right to use any trademark,
+service mark, tradename, or logo of the Copyright Holder.
+
+(13)  This license includes the non-exclusive, worldwide,
+free-of-charge patent license to make, have made, use, offer to sell,
+sell, import and otherwise transfer the Package with respect to any
+patent claims licensable by the Copyright Holder that are necessarily
+infringed by the Package. If you institute patent litigation
+(including a cross-claim or counterclaim) against any party alleging
+that the Package constitutes direct or contributory patent
+infringement, then this Artistic License to you shall terminate on the
+date that such litigation is filed.
+
+(14)  Disclaimer of Warranty:
+THE PACKAGE IS PROVIDED BY THE COPYRIGHT HOLDER AND CONTRIBUTORS "AS
+IS" AND WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES. THE IMPLIED
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, OR
+NON-INFRINGEMENT ARE DISCLAIMED TO THE EXTENT PERMITTED BY YOUR LOCAL
+LAW. UNLESS REQUIRED BY LAW, NO COPYRIGHT HOLDER OR CONTRIBUTOR WILL
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES ARISING IN ANY WAY OUT OF THE USE OF THE PACKAGE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/META6.json
+++ b/META6.json
@@ -1,26 +1,27 @@
 {
-   "meta6" : "0",
-   "provides" : {
-      "Getopt::ForClass" : "lib/Getopt/ForClass.pm6"
-   },
-   "test-depends" : [
-      "Test",
-      "Test::META"
-   ],
-   "support" : {
-      "source" : "git://github.com/zostay/p6-Getopt-ForClass.git"
-   },
-   "perl" : "6.c",
-   "build-depends" : [],
-   "auth" : "github:zostay",
-   "source-url" : "git://github.com/zostay/p6-Getopt-ForClass.git",
-   "depends" : [],
-   "name" : "Getopt::ForClass",
-   "authors" : [
-      "Sterling Hanenkamp <hanenkamp@cpan.org>"
-   ],
-   "version" : "0.1",
-   "license" : "Artistic",
-   "description" : "Use MAIN to dispatch to a class."
+  "auth" : "github:zostay",
+  "authors" : [
+    "Sterling Hanenkamp <hanenkamp@cpan.org>"
+  ],
+  "build-depends" : [ ],
+  "depends" : [ ],
+  "description" : "Use MAIN to dispatch to a class.",
+  "license" : "Artistic-2.0",
+  "meta6" : "0",
+  "name" : "Getopt::ForClass",
+  "perl" : "6.c",
+  "provides" : {
+    "Getopt::ForClass" : "lib/Getopt/ForClass.pm6"
+  },
+  "resources" : [ ],
+  "source-url" : "git://github.com/zostay/p6-Getopt-ForClass.git",
+  "support" : {
+    "source" : "git://github.com/zostay/p6-Getopt-ForClass.git"
+  },
+  "tags" : [ ],
+  "test-depends" : [
+    "Test",
+    "Test::META"
+  ],
+  "version" : "0.1"
 }
-

--- a/README.md
+++ b/README.md
@@ -1,12 +1,89 @@
-[![Build Status](https://travis-ci.org/samgwise/p6-Getopt-ForClass.svg?branch=master)](https://travis-ci.org/samgwise/p6-Getopt-ForClass)
+NAME
+====
 
-class Mu $
-----------
+Getopt::ForClass - Use MAIN to dispatch to a class
 
-The class for which to build MAIN.
+SYNOPSIS
+========
 
-class Mu $
-----------
+    #!/usr/bin/env perl6
+    use Getopt::ForClass;
 
-Smartmatcher naming methods to make available on the command-line.
+    class MyApp {
+        has $.token;
 
+        method BUILD(:$!token) { }
+
+        method list-things(:$filter) { ... }
+        method add-thing($name) { ... }
+        method remove-thing($name, Bool :$cascade) { ... }
+    }
+
+    our &MAIN := build-main-for-class(
+        class => MyApp,
+    );
+
+    # On the command-line:
+    # % myapp --token=abc123 list-things --filter red
+    # % myapp --token=abc123 add-thing socks
+    # % myapp --token=abc123 remove-thing shrubbery --cascade
+
+DESCRIPTION
+===========
+
+This module exports a function, `build-main-for-class`, which takes a class type and uses it to setup a `MAIN` function that is able to execut the various methods of that class as sub-commands of the script.
+
+METHODS
+=======
+
+sub build-main-for-class
+------------------------
+
+    sub build-main-for-class(:$class!, :$methods = *) returns Routine:D
+
+This routine is exported by default. Given a `$class`, it will inspect that class and generate a `MAIN` function that is able to execute one of the methods of that class per run. It does this by generating a multisub, which may be assigned to `MAIN` in your program.
+
+Specifically, it does the following:
+
+  * 1. One `MAIN` multisub candidate is generated for each method in the class (limited by the smartmatch in `$methods`, see below).
+
+  * 2. Each `MAIN` candidate will provide command-line options based upon the `BUILD` submethod for the class. If no `BUILD` is provided, then no attributes will be set during construction.
+
+  * 3. The first positional argument accepted by each `MAIN` candidate is the name of one of the methods in the class.
+
+  * 4. The remaining positional and named arguments for each `MAIN` candidate are those taken from `BUILD` and those taken from the method of the class this candidate is associated with.
+
+When run, the `MAIN` method will first construct an object by calling the `new` method and passing to that method the same parameters as are defined in `BUILD`. It will then call the method for the selected candidate passing to that method all the arguments given on the command-line.
+
+sub MAIN_HELPER
+---------------
+
+    sub MAIN_HELPER($retval = 0)
+
+In addition to generating the `MAIN` routine, this module also provides a `MAIN_HELPER`, which will parse the command-line arguments to call the generated `MAIN` subroutine.
+
+This implementation will attempt to locate the most appropriate `MAIN` candidate using parameters given on the command-line. It will then organize and pass the command-line parameters to the `MAIN` candidate. This works somewhat differently from the Perl6 native `MAIN_HELPER` (at least as of this writing):
+
+  * * Any parameter of the form `--NAME=VALUE` will be treated as a named parameter. If the candidate explicitly defines that named parameter with a numeric type, the value will be converted to a number before being passed. If it defines a boolean type, the value will be converted to False if it matches "1", "y", "yes", or "true" (using a case insensitive match) and True otherwise. Otherwise, the string will be passed as is.
+
+  * * Any parameter of the form `--NAME` will be treated as a named parameter. If the candidate explicityly defines that named parameter as boolean, it will be set to a True value. Any other type is assumed to require a parameter so the next argument on the command-line must be a parameter. If the type of the named parameter is numeric, the value will be coerced into a number before being passed.
+
+  * * Any parameter of the form `--no-NAME` will be treated as a named parameter. The named parameter will be set to False.
+
+  * * Any parameter following `--` will be treated as a positional parameter, even if it takes on one of the forms named above.
+
+  * * Any other parameter is treated as a positional parameter. Positional parameters will be converted to boolean or numbers based upon type.
+
+This implementation is less picky about the ordering of parameters than the built-in Perl 6 implementation that is in place as of this writing.
+
+AUTHOR
+======
+
+Sterling Hanenkamp `<hanenkamp@cpan.org> `
+
+COPYRIGHT & LICENSE
+===================
+
+Copyright 2016 Sterling Hanenkamp.
+
+This software is licensed under the same terms as Perl 6.

--- a/README.md
+++ b/README.md
@@ -1,89 +1,12 @@
-NAME
-====
+[![Build Status](https://travis-ci.org/samgwise/p6-Getopt-ForClass.svg?branch=master)](https://travis-ci.org/samgwise/p6-Getopt-ForClass)
 
-Getopt::ForClass - Use MAIN to dispatch to a class
+class Mu $
+----------
 
-SYNOPSIS
-========
+The class for which to build MAIN.
 
-    #!/usr/bin/env perl6
-    use Getopt::ForClass;
+class Mu $
+----------
 
-    class MyApp {
-        has $.token;
+Smartmatcher naming methods to make available on the command-line.
 
-        method BUILD(:$!token) { }
-
-        method list-things(:$filter) { ... }
-        method add-thing($name) { ... }
-        method remove-thing($name, Bool :$cascade) { ... }
-    }
-
-    our &MAIN := build-main-for-class(
-        class => MyApp,
-    );
-
-    # On the command-line:
-    # % myapp --token=abc123 list-things --filter red
-    # % myapp --token=abc123 add-thing socks
-    # % myapp --token=abc123 remove-thing shrubbery --cascade
-
-DESCRIPTION
-===========
-
-This module exports a function, `build-main-for-class`, which takes a class type and uses it to setup a `MAIN` function that is able to execut the various methods of that class as sub-commands of the script.
-
-METHODS
-=======
-
-sub build-main-for-class
-------------------------
-
-    sub build-main-for-class(:$class!, :$methods = *) returns Routine:D
-
-This routine is exported by default. Given a `$class`, it will inspect that class and generate a `MAIN` function that is able to execute one of the methods of that class per run. It does this by generating a multisub, which may be assigned to `MAIN` in your program.
-
-Specifically, it does the following:
-
-  * 1. One `MAIN` multisub candidate is generated for each method in the class (limited by the smartmatch in `$methods`, see below).
-
-  * 2. Each `MAIN` candidate will provide command-line options based upon the `BUILD` submethod for the class. If no `BUILD` is provided, then no attributes will be set during construction.
-
-  * 3. The first positional argument accepted by each `MAIN` candidate is the name of one of the methods in the class.
-
-  * 4. The remaining positional and named arguments for each `MAIN` candidate are those taken from `BUILD` and those taken from the method of the class this candidate is associated with.
-
-When run, the `MAIN` method will first construct an object by calling the `new` method and passing to that method the same parameters as are defined in `BUILD`. It will then call the method for the selected candidate passing to that method all the arguments given on the command-line.
-
-sub MAIN_HELPER
----------------
-
-    sub MAIN_HELPER($retval = 0)
-
-In addition to generating the `MAIN` routine, this module also provides a `MAIN_HELPER`, which will parse the command-line arguments to call the generated `MAIN` subroutine.
-
-This implementation will attempt to locate the most appropriate `MAIN` candidate using parameters given on the command-line. It will then organize and pass the command-line parameters to the `MAIN` candidate. This works somewhat differently from the Perl6 native `MAIN_HELPER` (at least as of this writing):
-
-  * * Any parameter of the form `--NAME=VALUE` will be treated as a named parameter. If the candidate explicitly defines that named parameter with a numeric type, the value will be converted to a number before being passed. If it defines a boolean type, the value will be converted to False if it matches "1", "y", "yes", or "true" (using a case insensitive match) and True otherwise. Otherwise, the string will be passed as is.
-
-  * * Any parameter of the form `--NAME` will be treated as a named parameter. If the candidate explicityly defines that named parameter as boolean, it will be set to a True value. Any other type is assumed to require a parameter so the next argument on the command-line must be a parameter. If the type of the named parameter is numeric, the value will be coerced into a number before being passed.
-
-  * * Any parameter of the form `--no-NAME` will be treated as a named parameter. The named parameter will be set to False.
-
-  * * Any parameter following `--` will be treated as a positional parameter, even if it takes on one of the forms named above.
-
-  * * Any other parameter is treated as a positional parameter. Positional parameters will be converted to boolean or numbers based upon type.
-
-This implementation is less picky about the ordering of parameters than the built-in Perl 6 implementation that is in place as of this writing.
-
-AUTHOR
-======
-
-Sterling Hanenkamp `<hanenkamp@cpan.org> `
-
-COPYRIGHT & LICENSE
-===================
-
-Copyright 2016 Sterling Hanenkamp.
-
-This software is licensed under the same terms as Perl 6.


### PR DESCRIPTION
Updated meta to specify version two of the artistic license and added a copy of the Artistic license 2.0 to the repo.

Added a .gitignore to skip .precomp and editor related files.